### PR TITLE
add metric conversions for ingredients in cookie recipes

### DIFF
--- a/recipes/peanut-butter-english
+++ b/recipes/peanut-butter-english
@@ -1,18 +1,18 @@
 Co.Lab peanut butter cookie recipe (original by Yellow Dog Bread co.)
 
 INGREDIENTS
-1 and 1/2 cups butter
-2/3 cup sugar
-2/3 cup brown sugar
-1 and 2/3 cup peanut butter
+1 and 1/2 cups (340 g) butter
+2/3 cup (80 g) sugar
+2/3 cup (130 g) brown sugar
+1 and 2/3 cup (470 g) peanut butter
 2 eggs
-1 teaspoon vanilla extract
-2 cups flour
-2 teaspoon baking powder
-1/2 teaspoon salt 
+1 teaspoon (5 g) vanilla extract
+2 cups (250 g) flour
+2 teaspoon (10 g) baking powder
+1/2 teaspoon (2.5 g) salt
 
 DIRECTIONS
-1. Preheat oven to 350 ºF degrees.
+1. Preheat oven to 350 ºF (180 ºC) degrees.
 2. Allow butter to come up to room temperature.
 3. Put butter into mixing bowl, beat until soft.
 4. Add both sugars, beat on medium speed until light and fluffy.

--- a/recipes/peanut-butter-spanish
+++ b/recipes/peanut-butter-spanish
@@ -1,15 +1,15 @@
 Receta de galletas de mantequilla de maní Co.Lab (original de Yellow Dog Bread co.)
 
 INGREDIENTES
-1 y 1/2 tazas de mantequilla
-2/3 taza de azúcar
-2/3 taza de azúcar morena
-1 y 2/3 taza de mantequilla de maní
+1 y 1/2 tazas (340 grs) de mantequilla
+2/3 taza (80 grs) de azúcar
+2/3 taza (130 grs) de azúcar morena
+1 y 2/3 taza (470 grs) de mantequilla de maní
 2 huevos
-1 cucharadita de extracto de vainilla
-2 tazas de harina
-2 cucharaditas de levadura en polvo
-1/2 cucharadita de sal
+1 cucharadita (5 grs) de extracto de vainilla
+2 tazas (250 grs) de harina
+2 cucharaditas (10 grs) de levadura en polvo
+1/2 cucharadita (2,5 grs) de sal
 
 DIRECCIONES
 1. Precalienta el horno a 180ºC.


### PR DESCRIPTION
Sources: 
* https://www.thecalculatorsite.com/cooking/cups-grams.php
* https://metric-calculator.com
* google.com

Conversions made using US cups and US tsp